### PR TITLE
Use package git instead of git-core: Don't pull in obsolete packages

### DIFF
--- a/build.sh
+++ b/build.sh
@@ -110,7 +110,7 @@ R=${BUILDDIR}/chroot
 CHROOT_SCRIPTS=${CHROOT_SCRIPTS:=""}
 
 # Packages required for bootstrapping
-REQUIRED_PACKAGES="debootstrap debian-archive-keyring qemu-user-static binfmt-support dosfstools rsync bmap-tools whois git-core"
+REQUIRED_PACKAGES="debootstrap debian-archive-keyring qemu-user-static binfmt-support dosfstools rsync bmap-tools whois git"
 
 # Missing packages that need to be installed
 MISSING_PACKAGES=""


### PR DESCRIPTION
git-core is a transitional package since April 2010 and the no more
supported Debian 6 Squeeze.

This makes build.sh stop pulling in ancient and obsolete transitional packages onto people's systems.

This is the same pull request as drtyhlpr/rpi2-gen-image#35, just for the rpi3 branch.
